### PR TITLE
[チャット]ミュート機能実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,17 @@
         "typeorm",
         "websockets"
     ],
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "[typescriptreact]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "eslint.alwaysShowStatus": true,
-    "eslint.workingDirectories": [ "./frontend" ]
+    "eslint.workingDirectories": [
+        "./frontend",
+        "./backend"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "chatlist",
         "nestjs",
+        "typeorm",
         "websockets"
     ],
     "editor.formatOnSave": true,

--- a/backend/src/Chat/chat-mute-user.controller.ts
+++ b/backend/src/Chat/chat-mute-user.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { ChatMuteUserService } from './chat-mute-user.service';
+import { ChatMuteUser } from './chat-mute-user.entity';
+
+@Controller('chat-mute-user')
+export class ChatMuteUserController {
+  constructor(private service: ChatMuteUserService) {}
+
+  @Get()
+  get(): Promise<ChatMuteUser[]> {
+    return this.service.getList();
+  }
+}

--- a/backend/src/Chat/chat-mute-user.entity.ts
+++ b/backend/src/Chat/chat-mute-user.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class ChatMuteUser {
+  @PrimaryColumn()
+  muteUserId: string;
+
+  @PrimaryColumn()
+  mutedUserId: string;
+}

--- a/backend/src/Chat/chat-mute-user.module.ts
+++ b/backend/src/Chat/chat-mute-user.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChatMuteUserController } from './chat-mute-user.controller';
+import { ChatMuteUser } from './chat-mute-user.entity';
+import { ChatMuteUserService } from './chat-mute-user.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChatMuteUser])],
+  controllers: [ChatMuteUserController],
+  providers: [ChatMuteUserService],
+})
+export class ChatMuteUserModule {}

--- a/backend/src/Chat/chat-mute-user.service.ts
+++ b/backend/src/Chat/chat-mute-user.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChatMuteUser } from './chat-mute-user.entity';
+
+@Injectable()
+export class ChatMuteUserService {
+  constructor(
+    @InjectRepository(ChatMuteUser)
+    private chatMuteRepository: Repository<ChatMuteUser>,
+  ) {}
+
+  async getList(): Promise<ChatMuteUser[]> {
+    const rows: ChatMuteUser[] = await this.chatMuteRepository.find();
+    return rows;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,7 +4,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { HealthCheck } from './healthCheck/healthCheck.entity';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { ChatGateway } from './Chat/chat.gateway';
+import { ChatMuteUserModule } from './Chat/chat-mute-user.module';
 import * as dotenv from 'dotenv';
+import { ChatMuteUser } from './Chat/chat-mute-user.entity';
 
 dotenv.config();
 
@@ -15,12 +17,16 @@ const options: PostgresConnectionOptions = {
   username: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
-  entities: [HealthCheck],
+  entities: [HealthCheck, ChatMuteUser],
   synchronize: true,
 };
 
 @Module({
-  imports: [TypeOrmModule.forRoot(options), HealthCheckModulle],
+  imports: [
+    TypeOrmModule.forRoot(options),
+    HealthCheckModulle,
+    ChatMuteUserModule,
+  ],
   providers: [ChatGateway],
 })
 export class AppModule {}

--- a/frontend/src/Chat/Chat.tsx
+++ b/frontend/src/Chat/Chat.tsx
@@ -3,6 +3,7 @@ import './styles.css'
 import io from 'socket.io-client'
 import { useLocation } from 'react-router-dom'
 import { type ReactElement } from 'react'
+import axios from 'axios'
 
 interface messageEventType {
   key: number
@@ -21,6 +22,11 @@ interface messageItem {
   body: JSX.Element
 }
 
+interface muteUserList {
+  muteUserId: string
+  mutedUserId: string
+}
+
 // const ServerURL: string = "wss://ws.postman-echo.com/raw";
 const ServerURL: string = 'ws://localhost:3002'
 export function Chat(): ReactElement {
@@ -33,6 +39,22 @@ export function Chat(): ReactElement {
 
   const location = useLocation()
   const { room, name }: State = location.state
+
+  React.useEffect(() => {
+    axios.defaults.baseURL = 'http://localhost:3001'
+    axios
+      .get('/chat-mute-user')
+      .then((response) => {
+        setMutedUserList(
+          response.data
+            .filter((value: muteUserList) => name === value.muteUserId)
+            .map((value: muteUserList) => value.mutedUserId)
+        )
+      })
+      .catch(() => {
+        alert('エラーです！')
+      })
+  }, [])
 
   const makeItem = (item: messageEventType): messageItem => {
     const outerClassName: string =


### PR DESCRIPTION
[対応内容]
resolve #11 

- [x] DBにミュート管理用のテーブル追加
- [x] バックエンドにミュート一覧を取得するためのAPIを作成
- [x] フロントにて、ミュートユーザのメッセージを非表示にする機能を実装。

[未対応事項]
以下は別チケットで対応を行う。

- ユーザテーブルを未作成のため、暫定的にミュート管理テーブルはユーザ名を格納する仕様にしている。将来的にはWikiのER図と合わせる。
- バックエンドで全ユーザ分のミュートリストを取得して、フロントエンドで非表示にしている。パフォーマンス問題があれば、「特定のユーザ分のミュートリストを取得するAPI」を追加作成する。
- ユーザをミュートするためのUIを未作成。開発の動作確認はDBに直接レコードを挿入して実施する。動作確認用テーブルをmigrationするための仕組みを導入する必要あり。
- 暫定的に、チャット画面の名前を押すと一時的に非表示にする機能を実装。
- 