### PR TITLE
lint error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,8 @@ re:down build up
 .PHONY:prune
 prune:
 	docker system  prune
+
+.PHONY:lint
+lint:
+	cd ./frontend && npm run lint && npm run format
+	cd ./backend && npm run lint && npm run format

--- a/frontend/src/Chat/Chat.tsx
+++ b/frontend/src/Chat/Chat.tsx
@@ -130,9 +130,9 @@ export function Chat(): ReactElement {
       }
     })
 
-   socket.emit('channelNotification', room)
+    socket.emit('channelNotification', room)
 
-   return () => {
+    return () => {
       socket.off('connect')
       socket.off('message')
       socket.off('banNotification')


### PR DESCRIPTION
resolve #66 

- [x] Lintエラーの解消
- [x] Makefileにlintコマンドの追加

[原因]
GitHub ActionsへのフロントエンドLint処理追加と並行してmergeしたコミットが原因で、Lintエラーとなっていました。