### PR TITLE
seeding sample data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "Hght",
         "nestjs",
         "openapi",
+        "ormconfig",
         "powerup",
         "typeorm",
         "websockets"

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,15 @@ prune:
 lint:
 	cd ./frontend && npm run lint && npm run format
 	cd ./backend && npm run lint && npm run format
+
+.PHONY:create
+create:
+	docker exec -it back npm run typeorm:create
+
+.PHONY:migrate
+migrate:
+	docker exec -it back npm run typeorm:run
+
+.PHONY:revert
+revert:
+	docker exec -it back npm run typeorm:revert

--- a/backend/migrations/1676466055353-migrations.ts
+++ b/backend/migrations/1676466055353-migrations.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migrations1676466055353 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO public.chat_room(name, created_by, "isPublic") VALUES('room1', 'aa', false);`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE from public.chat_room WHERE name = 'room1' AND created_by = 'aa' AND "isPublic" = false;`,
+    );
+  }
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,7 +41,7 @@
         "supertest": "^6.1.3",
         "ts-jest": "29.0.3",
         "ts-loader": "^9.2.3",
-        "ts-node": "^10.0.0",
+        "ts-node": "^10.9.1",
         "tsconfig-paths": "4.1.1",
         "typescript": "^4.7.4"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,18 +17,22 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "typeorm:create": "npm run typeorm migration:create ./migrations/",
+    "typeorm:run": "npm run typeorm migration:run -- --dataSource src/config/ormconfig.ts",
+    "typeorm:revert": "npm run typeorm migration:revert -- --dataSource src/config/ormconfig.ts"
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
-    "@nestjs/typeorm": "^9.0.1",
-    "dotenv": "^16.0.3",
-    "pg": "^8.9.0",
     "@nestjs/platform-socket.io": "^9.2.1",
+    "@nestjs/typeorm": "^9.0.1",
     "@nestjs/websockets": "^9.2.1",
     "@types/socket.io": "^3.0.2",
+    "dotenv": "^16.0.3",
+    "pg": "^8.9.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "typeorm": "^0.3.11"
@@ -52,7 +56,7 @@
     "supertest": "^6.1.3",
     "ts-jest": "29.0.3",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
+    "ts-node": "^10.9.1",
     "tsconfig-paths": "4.1.1",
     "typescript": "^4.7.4"
   },

--- a/backend/src/config/ormconfig.ts
+++ b/backend/src/config/ormconfig.ts
@@ -1,0 +1,15 @@
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+// Check typeORM documentation for more information.
+export const ormconfig = new DataSource({
+  type: 'postgres',
+  host: 'postgres', //Container name in docker-compose.
+  port: 5432,
+  username: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB,
+  migrations: ['migrations/*.ts'],
+});


### PR DESCRIPTION
 #35 の関連です。

一度pendingにしていたseedingに対応できるようにしました。
backendのmigrationsディレクトリにあるmigrationファイルに従ってseedingされます。
今時点で入れているのは「chat_roomに１件のレコード追加をする」というseeding です。


[使い方]
1. 一度バックエンド＋DBのdockerを起動する。（この時点でDBのプロセス起動とDBのテーブル定義作成ができている必要がある。）
2. 別のterminalから`make migrate`を実行。

[今後の流れ]
問題なければ、別チケットで以下の対応を行います。

- healthチェック用のテーブルへの初期データ用migrationファイル作成
- ゲストユーザ用のデータ作成migrationファイル作成