### PR TITLE
spellチェックの範囲拡大

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -2,18 +2,10 @@ name: spell check
 run-name: spell check by ${{ github.actor }}
 on: [push]
 jobs:
-  Spell-check-backend:
+  Spell-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Backend spell check
-        run: npx --package cspell --yes cspell lint --config .vscode/cspell.json "backend/src/**/*.ts"
-
-  Spell-check-frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - name: Frontend spell check
-        run:  npx --package cspell --yes cspell lint --config .vscode/cspell.json "frontend/src/**/*.tsx"
+      - name: spell check
+        run: make spell-check

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -9,6 +9,12 @@
         "typeorm",
         "websockets",
         "matchlist",
+        "signin",
+        "Foles",
+        "hadolint",
+        "fclean",
+        "swaggerapi",
+        "webfonts",
         "Codeball",
         "pendings"
     ]

--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,15 @@ revert:wait-until-backend-ready
 cypress-run:wait-until-frontend-ready
 	cd ./cypress && npm install && npm run cypress:run
 
-BACKEND_HEALTHCHECK_URL=localhost:3001/health
+BACKEND_HEALTH_CHECK_URL=localhost:3001/health
 .PHONY:wait-until-backend-ready
 wait-until-backend-ready:
-	until (curl -i ${BACKEND_HEALTHCHECK_URL} | grep "200 OK") do sleep 10; done
+	until (curl -i ${BACKEND_HEALTH_CHECK_URL} | grep "200 OK") do sleep 10; done
 
-FRONTEND_HEALTHCHECK_URL=localhost:3000
+FRONTEND_HEALTH_CHECK_URL=localhost:3000
 .PHONY:wait-until-frontend-ready
 wait-until-frontend-ready:wait-until-backend-ready
-	until (curl -i ${FRONTEND_HEALTHCHECK_URL} | grep "200 OK") do sleep 10; done
+	until (curl -i ${FRONTEND_HEALTH_CHECK_URL} | grep "200 OK") do sleep 10; done
 
 .PHONY:spell-check
 spell-check:

--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,7 @@ FRONTEND_HEALTHCHECK_URL=localhost:3000
 .PHONY:wait-until-frontend-ready
 wait-until-frontend-ready:wait-until-backend-ready
 	until (curl -i ${FRONTEND_HEALTHCHECK_URL} | grep "200 OK") do sleep 10; done
+
+.PHONY:spell-check
+spell-check:
+	npx --package cspell --yes cspell lint --config .vscode/cspell.json "." --gitignore --show-suggestions


### PR DESCRIPTION
resolve #245 

今までは、`backend/src`と`frontend/src`しか見てなかったですが、他のファイルも見れるようにしました。
便利なオプション`--gitignore`を使って、git管理しているファイルのみを対象としています。