### PR TITLE
docker compose profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ENV_FILE=./config/.env_docker
 DC_CMD=docker compose
-DC_OPTIONS=--env-file ${ENV_FILE} -f ./docker-compose.yml
+#提出前に以下の行はコメントアウトすることでswaggerが起動しなくなる。
+DC_PROFILE=--profile debug
+DC_OPTIONS=--env-file ${ENV_FILE} -f ./docker-compose.yml ${DC_PROFILE}
 
 include ${ENV_FILE}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,15 @@ services:
       - ./swagger/api.yml:/api.yml
     environment:
       SWAGGER_JSON: /api.yml
+    profiles:
+      - debug
 
   swagger-editor:
     image: swaggerapi/swagger-editor:latest
     ports:
-    - 8081:8080
+      - 8081:8080
+    profiles:
+      - debug
 
 networks:
   trans:


### PR DESCRIPTION
#85 

docker composeのprofile機能を使って、起動するサーバを選択できる。

事前に、profileの設定を組み込む←本PR。
この後提出前に、debugの行を削除するとswaggerは起動しなくなる。