### PR TITLE
Feat/283 enable auth globally

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,28 +1,20 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  Post,
-  Request,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Request } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { Auth42Param } from 'src/common/params/user.params';
 import { UserSignInDto } from 'src/common/dto/users.dto';
-import { JwtAuthGuard } from './guards/jwt.guard';
 import { SigninResDto } from 'src/common/dto/auth.dto';
+import { Public } from './public.decorator';
 
 @Controller('auth')
 export class AuthController {
   constructor(private service: AuthService) {}
 
+  @Public()
   @Post('signin')
   async signIn(@Body() body: UserSignInDto): Promise<SigninResDto> {
     return this.service.signIn(body);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Get('protected')
   async getProtectedData(@Request() req) {
     /*
@@ -38,6 +30,7 @@ export class AuthController {
     return req.user;
   }
 
+  @Public()
   @Get('42/:code')
   async auth42(@Param() param: Auth42Param): Promise<string> {
     const token = await this.service.request42AuthToken(param.code);

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,6 +5,8 @@ import { AuthService } from './auth.service';
 import { TwoFactorAuthController } from './twoFactorAuth.controller';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './guards/jwt.guard';
 
 @Module({
   imports: [
@@ -21,6 +23,13 @@ import { JwtStrategy } from './strategies/jwt.strategy';
     }),
   ],
   controllers: [AuthController, TwoFactorAuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
 })
 export class AuthModule {}

--- a/backend/src/auth/guards/jwt.guard.ts
+++ b/backend/src/auth/guards/jwt.guard.ts
@@ -1,5 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../public.decorator';
 
+// https://docs.nestjs.com/security/authentication#enable-authentication-globally
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  // canActivateメソッドはリクエストが特定のエンドポイントにアクセスできるかどうかを判断
+  canActivate(context: ExecutionContext) {
+    // isPublic変数にエンドポイントがPublicデコレータでマークされているかどうかを代入
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    // エンドポイントがPublicデコレータでマークされている場合、認証をスキップ
+    if (isPublic) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/auth/public.decorator.ts
+++ b/backend/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/healthCheck/healthCheck.controller.ts
+++ b/backend/src/healthCheck/healthCheck.controller.ts
@@ -1,11 +1,13 @@
 import { Get, Controller } from '@nestjs/common';
 import { HealthCheckService } from './healthCheck.service';
 import { HealthDto } from 'src/common/dto/health.dto';
+import { Public } from 'src/auth/public.decorator';
 
 @Controller('health')
 export class HealthCheckController {
   constructor(private service: HealthCheckService) {}
 
+  @Public()
   @Get()
   get(): Promise<HealthDto> {
     return this.service.get();

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -27,11 +27,13 @@ import { UserIdParam } from 'src/common/params/user.params';
 import { Response } from 'express';
 import * as fs from 'fs';
 import { promisify } from 'util';
+import { Public } from 'src/auth/public.decorator';
 
 @Controller('user')
 export class UsersController {
   constructor(private service: UsersService) {}
 
+  @Public()
   @Post()
   signUp(@Body() body: UserSignUpReqDto): Promise<UserSignUpResDto> {
     return this.service.createUser(body);
@@ -95,6 +97,7 @@ export class UsersController {
     return this.service.deletePending(body);
   }
 
+  @Public()
   @Get('user_avatar/:id')
   async getAvatar(
     @Param() param: UserIdParam,
@@ -123,6 +126,7 @@ export class UsersController {
     return await this.service.getUserMatchHistory(param.id);
   }
 
+  @Public()
   @Post('check/username-availability')
   async checkUsername(
     @Body() body: UsernameCheckRequestDto,

--- a/frontend/src/Game/components/MatchList/MatchList.tsx
+++ b/frontend/src/Game/components/MatchList/MatchList.tsx
@@ -3,9 +3,6 @@ import { useNavigate } from 'react-router-dom'
 import { getMatches } from '../../../utils/matchAxios'
 import { getAllUsersRequest } from '../../../utils/userAxios'
 import ListGroup from 'react-bootstrap/ListGroup'
-import axios from 'axios'
-
-axios.defaults.baseURL = process.env.REACT_APP_BACKEND_HTTP_BASE_URL
 
 function listMatches(matches: MatchDto[], users: User[]): ReactElement[] {
   const navigate = useNavigate()

--- a/frontend/src/utils/authAxios.tsx
+++ b/frontend/src/utils/authAxios.tsx
@@ -1,5 +1,6 @@
 import axios, { type AxiosError } from 'axios'
 import { localStorageKey } from '../constants'
+import jwtAxios from './axiosConfig'
 
 export function signIn(
   signInData: signIn,
@@ -31,7 +32,7 @@ export function validateJwtToken(
     return
   }
 
-  axios
+  jwtAxios
     .get('/auth/protected', {
       headers: {
         Authorization: 'Bearer ' + jwtToken
@@ -86,7 +87,7 @@ export function getOTPData(
   userName: string,
   callback: (res: { secret: string; qrCode: string }) => void
 ): void {
-  axios
+  jwtAxios
     .get<{ secret: string; qrCode: string }>(`/auth/2fa/setup/${userName}`)
     .then((res): void => {
       callback(res.data)
@@ -100,7 +101,7 @@ export function enable2FA(
   enableTwoFactorAuth: EnableTwoFactorAuth,
   callback: (isEnabled: boolean) => void
 ): void {
-  axios
+  jwtAxios
     .post('/auth/2fa/enable', enableTwoFactorAuth)
     .then((res): void => {
       callback(res.data)
@@ -111,7 +112,7 @@ export function enable2FA(
 }
 
 export function disable2FA(userId: number, callback: (res: any) => void): void {
-  axios
+  jwtAxios
     .post('/auth/2fa/disable', { userId })
     .then((res): void => {
       callback(res.data)
@@ -125,7 +126,7 @@ export function getIsTwoFactorEnabled(
   userId: number,
   callback: (res: boolean) => void
 ): void {
-  axios
+  jwtAxios
     .get<boolean>('/auth/2fa/status', {
       params: {
         userId
@@ -143,7 +144,7 @@ export function verifyOTP(
   verifyTwoFactorAuth: VerifyTwoFactorAuth,
   callback: (accessToken: string) => void
 ): void {
-  axios
+  jwtAxios
     .post('/auth/2fa/verify', verifyTwoFactorAuth)
     .then((res): void => {
       callback(res.data)

--- a/frontend/src/utils/axiosConfig.tsx
+++ b/frontend/src/utils/axiosConfig.tsx
@@ -1,0 +1,30 @@
+import axios from 'axios'
+import { localStorageKey } from '../constants'
+
+// 42APIはjwt tokenではなく別のheaderを使いそうなので今のところdefaultのaxios
+// 変更される可能性
+axios.defaults.baseURL = process.env.REACT_APP_BACKEND_HTTP_BASE_URL
+
+// Axiosのインスタンスを作成
+const jwtAxios = axios.create({
+  baseURL: process.env.REACT_APP_BACKEND_HTTP_BASE_URL
+})
+
+// リクエストインターセプターを設定
+jwtAxios.interceptors.request.use(
+  function (config) {
+    // リクエストが送信される前の処理
+    const token = localStorage.getItem(localStorageKey)
+
+    if (token !== null) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  async function (error) {
+    // リクエスト エラーの処理
+    return await Promise.reject(error)
+  }
+)
+
+export default jwtAxios

--- a/frontend/src/utils/chatBlockUserAxios.tsx
+++ b/frontend/src/utils/chatBlockUserAxios.tsx
@@ -1,10 +1,10 @@
-import axios from 'axios'
+import jwtAxios from './axiosConfig'
 
 export function getChatBlockUserRequest(
   user: User,
   callback: (members: blockUserList[]) => void
 ): void {
-  axios
+  jwtAxios
     .get('/chat-block-user/' + String(user.id))
     .then((response) => {
       callback(response.data)
@@ -18,7 +18,7 @@ export function updateChatBlockUserRequest(
   newBlockUser: blockUserList,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post<blockUserList>('/chat-block-user', newBlockUser)
     .then(callback)
     .catch((reason) => {
@@ -31,7 +31,7 @@ export function deleteChatBlockUserRequest(
   deleteBlockUser: blockUserListPK,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .delete('/chat-block-user', { data: deleteBlockUser })
     .then((_response) => {
       // 100ms後に更新する

--- a/frontend/src/utils/chatDMAxios.tsx
+++ b/frontend/src/utils/chatDMAxios.tsx
@@ -1,10 +1,10 @@
-import axios from 'axios'
+import jwtAxios from './axiosConfig'
 
 export function updateChatDMMembersRequest(
   requestData: ChatDMMembersPK,
   callback: (chatDMMembers: ChatDMMembers) => void
 ): void {
-  axios
+  jwtAxios
     .post<ChatDMMembers>('/chatDMMembers', requestData)
     .then((response) => {
       callback(response.data)

--- a/frontend/src/utils/chatRoomAxios.tsx
+++ b/frontend/src/utils/chatRoomAxios.tsx
@@ -1,11 +1,9 @@
-import axios from 'axios'
-
-axios.defaults.baseURL = process.env.REACT_APP_BACKEND_HTTP_BASE_URL
+import jwtAxios from './axiosConfig'
 
 export function getChatRoomRequest(
   callback: (value: ChatRoom[]) => void
 ): void {
-  axios
+  jwtAxios
     .get<ChatRoom[]>('/chatRoom')
     .then((response) => {
       callback(response.data)
@@ -19,7 +17,7 @@ export function getChatRoomIdRequest(
   roomId: number,
   callback: (value: ChatRoom) => void
 ): void {
-  axios
+  jwtAxios
     .get<ChatRoom[]>('/chatRoom')
     .then((response) => {
       response.data
@@ -34,7 +32,7 @@ export function getChatRoomIdRequest(
 }
 
 export function deleteChatRoomRequest(room: ChatRoom): void {
-  axios
+  jwtAxios
     .delete('/chatRoom/' + String(room.id))
     .then((_response) => {})
     .catch((reason) => {
@@ -47,7 +45,7 @@ export function createChatRoomRequest(
   requestData: ChatRoomReqDto,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post<ChatRoom>('/chatRoom', requestData)
     .then((_response) => {
       callback()
@@ -63,7 +61,7 @@ export function updateChatRoomRequest(
   requestData: ChatRoomReqDto,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post<ChatRoom>('/chatRoom/' + String(room.id), requestData)
     .then((_response) => {
       callback()
@@ -79,7 +77,7 @@ export function chatRoomAuthRequest(
   requestData: ChatRoomAuthReqDto,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post('/chatRoom/' + String(room.id) + '/auth', requestData)
     .then(() => {
       callback()

--- a/frontend/src/utils/chatRoomMemberAxios.tsx
+++ b/frontend/src/utils/chatRoomMemberAxios.tsx
@@ -1,11 +1,9 @@
-import axios from 'axios'
-
-axios.defaults.baseURL = process.env.REACT_APP_BACKEND_HTTP_BASE_URL
+import jwtAxios from './axiosConfig'
 
 export function getChatRoomMembersRequest(
   callback: (members: ChatRoomMember[]) => void
 ): void {
-  axios
+  jwtAxios
     .get<ChatRoomMember[]>('/chatRoomMembers')
     .then((response) => {
       callback(
@@ -32,7 +30,7 @@ export function updateChatRoomMembersRequest(
   requestData: ChatRoomMember,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post<ChatRoom>('/chatRoomMembers', requestData)
     .then((_response) => {
       callback()
@@ -47,7 +45,7 @@ export function deleteChatRoomMembersRequest(
   requestData: ChatRoomMemberPK,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .delete<ChatRoom>('/chatRoomMembers', { data: requestData })
     .then((_response) => {
       // 100ms後に更新する

--- a/frontend/src/utils/matchAxios.tsx
+++ b/frontend/src/utils/matchAxios.tsx
@@ -1,10 +1,10 @@
-import axios from 'axios'
+import jwtAxios from './axiosConfig'
 
 export function createMatch(
   match: MatchDto,
   callback: (id: number | undefined) => void
 ): void {
-  axios
+  jwtAxios
     .post<MatchDto>('/match', match)
     .then((response) => {
       callback(response.data.id)
@@ -15,7 +15,7 @@ export function createMatch(
 }
 
 export function getMatches(callback: (matches: MatchDto[]) => void): void {
-  axios
+  jwtAxios
     .get<MatchDto[]>('/match/matches')
     .then((response) => {
       callback(response.data)
@@ -29,7 +29,7 @@ export function getMatchById(
   id: number,
   callback: (match: MatchDto) => void
 ): void {
-  axios
+  jwtAxios
     .get<MatchDto>('/match/' + String(id))
     .then((response) => {
       callback(response.data)
@@ -40,7 +40,7 @@ export function getMatchById(
 }
 
 export function postMatchResult(matchResult: MatchResultDto): void {
-  axios
+  jwtAxios
     .post<MatchDto>('/match/result/' + String(matchResult.id), matchResult)
     .then((_response) => {})
     .catch((err) => {

--- a/frontend/src/utils/userAxios.tsx
+++ b/frontend/src/utils/userAxios.tsx
@@ -1,10 +1,9 @@
 import axios from 'axios'
 import { defaultAvatar } from '../User/components/SignIn'
-
-axios.defaults.baseURL = process.env.REACT_APP_BACKEND_HTTP_BASE_URL
+import jwtAxios from './axiosConfig'
 
 export function getAllUsersRequest(callback: (users: User[]) => void): void {
-  axios
+  jwtAxios
     .get<User[]>('/user/users')
     .then((response) => {
       callback(response.data)
@@ -19,7 +18,7 @@ export function getUserRequest(
   userId: number,
   callback: (user: User) => void
 ): void {
-  axios
+  jwtAxios
     .get<User>('/user/' + String(userId))
     .then((response) => {
       callback(response.data)
@@ -50,7 +49,7 @@ export function signUp(obj: signUp, callback: (id: number) => void): void {
 }
 
 export async function getAvatar(userId: number): Promise<string> {
-  const res = await axios.get<string>(`/user/user_avatar/${userId}`)
+  const res = await jwtAxios.get<string>(`/user/user_avatar/${userId}`)
   return res.data
 }
 
@@ -58,7 +57,7 @@ export function getFriendRequest(
   userId: number,
   callback: (user: User[]) => void
 ): void {
-  axios
+  jwtAxios
     .get<User[]>('/user/friends/' + String(userId))
     .then((response) => {
       callback(response.data)
@@ -73,7 +72,7 @@ export function getFriendPendingRequest(
   userId: number,
   callback: (user: User[]) => void
 ): void {
-  axios
+  jwtAxios
     .get<User[]>('/user/friends/pending/' + String(userId))
     .then((response) => {
       callback(response.data)
@@ -88,7 +87,7 @@ export function updateFriendPendingRequest(
   requestData: FriendRequestDto,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .post('/user/friends', requestData)
     .then((_response) => {
       callback()
@@ -107,7 +106,7 @@ export function deleteFriendRequest(
   const requestData: UserFriendDeleteRequestDto = {
     friendUserId: friendID
   }
-  axios
+  jwtAxios
     .delete<UserFriendDeleteRequestDto>('/user/friends/' + String(userID), {
       data: requestData
     })
@@ -124,7 +123,7 @@ export function deleteFriendPendingRequest(
   requestData: FriendRequestDto,
   callback: () => void
 ): void {
-  axios
+  jwtAxios
     .delete<FriendRequestDto>('/user/friends/pending', { data: requestData })
     .then((_response) => {
       callback()
@@ -139,7 +138,7 @@ export function getFriendsRequest(
   userId: number,
   callback: (user: User[]) => void
 ): void {
-  axios
+  jwtAxios
     .get<User[]>('/user/friends/' + String(userId))
     .then((response) => {
       callback(response.data)
@@ -154,7 +153,7 @@ export function getMatchHistoryById(
   id: number,
   callback: (matchHistory: UserMatchHistoryDto) => void
 ): void {
-  axios
+  jwtAxios
     .get<UserMatchHistoryDto>('/user/match_history/' + String(id))
     .then((response) => {
       callback(response.data)


### PR DESCRIPTION
resolve #283 

参考url https://docs.nestjs.com/security/authentication#enable-authentication-globally

backendにある全てのcontrollerをjwt認証が必要になるようにしました。
signup, singinなどのcontrollerはjwt認証が必要ではないので@Public decoratorを付けています。
※もし401 Unauthorizedのerrorが出た場合は@Public decoratorをつけてください。

frontendでは毎回headerにjwt tokenを付けないといけないので、jwtAxiosというaxiosのインスタンスを作りました。
axiosのインターセプター( https://axios-http.com/ja/docs/interceptors )というものを使い、jwt tokenを付与しています。
jwt認証が必要なapiエンドポイントにrequestする場合は、jwtAxiosを使ってください。
ただし、現在は必要ないと思うところにはaxiosを使っています。