### PR TITLE
Friendリクエスト拒否エラー対応

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -92,9 +92,9 @@ export class UsersController {
     return list;
   }
 
-  @Delete('friends/pending')
-  deleteFriendPending(@Body() body: FriendRequestDto) {
-    return this.service.deletePending(body);
+  @Delete('friends/pending/:from/:to')
+  deleteFriendPending(@Param('from') from: number, @Param('to') to: number) {
+    return this.service.deletePending(from, to);
   }
 
   @Public()

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -169,11 +169,11 @@ export class UsersService {
     }
   }
 
-  async deletePending(data: FriendRequestDto): Promise<void> {
+  async deletePending(from: number, to: number): Promise<void> {
     const pendingItem = await this.pendingRepository.findOne({
       where: {
-        from: data.from,
-        to: data.to,
+        from: from,
+        to: to,
       },
     });
 

--- a/frontend/src/User/components/Profile/FriendPendingList.tsx
+++ b/frontend/src/User/components/Profile/FriendPendingList.tsx
@@ -35,11 +35,7 @@ function RejectButton(props: {
   const { loginUser } = useContext(GlobalContext)
 
   const rejectRequest = (): void => {
-    const requestData = {
-      from: props.targetUserId,
-      to: loginUser.id
-    }
-    deleteFriendPendingRequest(requestData, () => {
+    deleteFriendPendingRequest(props.targetUserId, loginUser.id, () => {
       alert('フレンドリクエストを拒否しました！')
       props.updateFriendPendingList()
     })

--- a/frontend/src/User/components/Profile/OtherUserProfile.tsx
+++ b/frontend/src/User/components/Profile/OtherUserProfile.tsx
@@ -134,11 +134,7 @@ export function FriendInvitationButton(props: {
   }
 
   const sendRejectRequest = (): void => {
-    const requestData = {
-      from: loginUser.id,
-      to: props.targetUser.id
-    }
-    deleteFriendPendingRequest(requestData, () => {
+    deleteFriendPendingRequest(loginUser.id, props.targetUser.id, () => {
       alert('フレンドリクエストをキャンセルしました！')
       updateIsFriend()
       updateIsPending()

--- a/frontend/src/utils/userAxios.tsx
+++ b/frontend/src/utils/userAxios.tsx
@@ -120,11 +120,14 @@ export function deleteFriendRequest(
 }
 
 export function deleteFriendPendingRequest(
-  requestData: FriendRequestDto,
+  from: number,
+  to: number,
   callback: () => void
 ): void {
   jwtAxios
-    .delete<FriendRequestDto>('/user/friends/pending', { data: requestData })
+    .delete<FriendRequestDto>(
+      '/user/friends/pending/' + String(from) + '/' + String(to)
+    )
     .then((_response) => {
       callback()
     })

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -166,14 +166,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/friends_get_res'
+  /user/friends/{from}/{to}:
     delete:
       tags:
         - user
       summary: delete friend
       parameters:
-        - name: userID
+        - name: from
           required: true
-          description: id
+          in: path
+          schema:
+            type: integer
+        - name: to
+          required: true
           in: path
           schema:
             type: integer


### PR DESCRIPTION
fix #310 

`/users/friend/:id`と`/users/friend/pendings`がPATH重複として、前者として判断されていたので別のPATHとしてリクエストを行うように修正しました。