### PR TITLE
#14 #329

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,12 +2,13 @@ FROM node:latest
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY ./ ./
 
 RUN npm install
 
 EXPOSE 3001
 
-COPY ./ ./
+RUN npm run build
 
-CMD [ "npm", "run", "start:dev" ]
+CMD [ "node", "dist/src/main.js" ]
+# CMD [ "npm", "run", "start:dev" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - type: bind
-        source: ./frontend
-        target: /app
+    # volumes:
+    #   - type: bind
+    #     source: ./frontend
+    #     target: /app
     env_file:
       -  ./config/.env
 
@@ -23,10 +23,10 @@ services:
     ports:
       - "3001:3001"
       - "3002:3002"
-    volumes:
-      - type: bind
-        source: ./backend
-        target: /app
+    # volumes:
+    #   - type: bind
+    #     source: ./backend
+    #     target: /app
     env_file:
       -  ./config/.env
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,12 +2,10 @@ FROM node:latest
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY ./ ./
 
 RUN npm install
 
 EXPOSE 3000
-
-COPY ./ ./
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Close #14
Close #329

#14 に関して、bindmountは関係なく、volumeを解除しました、これで`make init`は不必要で`docker-compose up --build`での起動が可能になります。

#329 に関して、backend側は解決しましたが、frontでは同一ホスト上だとaxiosのbaseURLが変更されてしまうので、そのまま`npm start`にしました。